### PR TITLE
Modify .gitignore to include autogenerated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#user added files
+img/
+README.md
+
 # OS files
 *.DS_Store
 


### PR DESCRIPTION
I recommend modify .gitignore to include autogenerated files, since there's autogenerated files and folders that shouldn't be modified. It would help to be clearer to trace the structure of the project.