### PR TITLE
Wrap the code when knitting 

### DIFF
--- a/src/homework_2_data_wrangling_with_tidyverse.Rmd
+++ b/src/homework_2_data_wrangling_with_tidyverse.Rmd
@@ -14,7 +14,7 @@ output:
 
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE,tidy.opts = list(width.cutoff = 80), tidy = TRUE)
+knitr::opts_chunk$set(echo = TRUE,tidy.opts = list(width.cutoff = 60), tidy = TRUE)
 ```
 
 ```{r, include=FALSE}

--- a/src/homework_2_data_wrangling_with_tidyverse.Rmd
+++ b/src/homework_2_data_wrangling_with_tidyverse.Rmd
@@ -14,7 +14,7 @@ output:
 
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(echo = TRUE,tidy.opts = list(width.cutoff = 80), tidy = TRUE)
 ```
 
 ```{r, include=FALSE}


### PR DESCRIPTION
I recommend use a line in knitr option to wrap the source code when knitting, which comes from formatr package. 
It helps to produce source codes that won't exceed the page margins if using output document that has a fixed page width. For instance, if the comments gets too long.